### PR TITLE
Hard-gate bun audit in CI; pin patched postcss + mdast-util-to-hast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,31 @@ jobs:
       - name: Server logs (on failure)
         if: failure()
         run: cat /tmp/server.log || true
+
+      # Hard-gates on vulnerable direct/transitive deps. One advisory is
+      # ignored because it's upstream-blocked (uuid <14.0.0 via
+      # resend → svix@1.90.0, dev-/server-side, no exploitable code path) —
+      # see CLAUDE.md "Audit advisories" for context and removal triggers.
+      # Any new advisory fails the job.
+      - name: Dependency audit
+        run: bun audit --ignore=GHSA-w5hq-g745-h8pq
+
+  # Runs only on PRs (no baseline diff to compute on a push to main).
+  # Compares the PR's dependency manifest against main and flags
+  # high-severity advisories or license incompatibilities. Posts a summary
+  # comment on the PR when it finds something. continue-on-error while we
+  # establish a baseline of acceptable findings.
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        continue-on-error: true
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 #velite generated files
 .velite
 public/static
+
+# claude code local settings (per-machine tool allowlists)
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,13 @@ This is a Next.js 15 marketing website for Vortex, a columnar file format. The s
 - `next.config.ts` - Plausible proxy configuration
 
 The site is optimized for performance with font optimization, analytics integration, and responsive WebGL rendering.
+
+## Audit advisories
+
+`bun audit` is the source of truth for dependency advisories. State as of 2026-05-04:
+
+- **postcss `<8.5.10`** (GHSA-qx2v-qp2m-jg93, moderate XSS in CSS stringify). Multiple transitive resolutions — `next@16.2.4` pins `postcss@8.4.31` exactly, and `@tailwindcss/postcss@4.2.3` brings in `postcss@^8.5.6`. Resolved via `overrides.postcss = "8.5.10"` in `package.json`, which dedupes all transitives to the patched version. Drop the override after `next` and `@tailwindcss/postcss` ship releases that pull their transitives to ≥ 8.5.10.
+- **mdast-util-to-hast `<13.2.1`** (GHSA-4fh9-h7wg-q85m, moderate XSS via unsanitized class attribute). Pulled in by three independent paths (shiki/rehype-pretty-code, react-markdown, velite/@mdx-js/mdx) — all parents accept `^13.0.0`, so the lockfile resolved to 13.2.0 (pre-fix). Resolved via `overrides.mdast-util-to-hast = "^13.2.1"`. Drop the override after parents ship releases that pull a patched version directly; verify with `bun pm ls --all | grep mdast-util-to-hast` showing only ≥ 13.2.1.
+- **uuid `<14.0.0`** (GHSA-w5hq-g745-h8pq, moderate missing buffer bounds in v3/v5/v6 when `buf` provided). **Upstream-blocked.** Comes exclusively from `resend@6.12.2 → svix@1.90.0 → uuid@^10.0.0`. svix's declared range `^10.0.0` doesn't admit a 14.x override without risking the parent's CJS imports. Exposure is theoretical: `/api/subscribe` invokes Resend's send-email endpoint, which doesn't exercise svix's webhook-signing path, and the vulnerable code (v3/v5/v6 with explicit `buf`) isn't called. Remove the `--ignore` when `svix` (or `resend`) ships a release that bumps uuid to `^14.0.0`.
+
+CI hard-gates on `bun audit` (`.github/workflows/ci.yml`) with `--ignore=GHSA-w5hq-g745-h8pq` for the upstream-blocked uuid advisory. Any new advisory fails the job. The `dependency-review-action` PR job is a separate gate (license/severity-focused) that remains `continue-on-error: true` while a baseline of acceptable findings is established.

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,10 @@
       },
     },
   },
+  "overrides": {
+    "mdast-util-to-hast": "^13.2.1",
+    "postcss": "8.5.10",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -425,7 +429,7 @@
 
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
-    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA=="],
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
@@ -511,7 +515,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
@@ -642,8 +646,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "4.2.3",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "postcss": "8.5.10",
+    "mdast-util-to-hast": "^13.2.1"
   }
 }


### PR DESCRIPTION
## Summary

Adds a hard `bun audit` gate to CI plus a `dependency-review-action` PR-only job, and resolves the two transitive advisories that have a published fix:

**Triage (3 advisories at branch time):**

| Advisory | Severity | Disposition |
|---|---|---|
| GHSA-qx2v-qp2m-jg93 (`postcss <8.5.10`, XSS in CSS stringify) | moderate | **Override** to `8.5.10` |
| GHSA-4fh9-h7wg-q85m (`mdast-util-to-hast <13.2.1`, XSS via class attr) | moderate | **Override** to `^13.2.1` |
| GHSA-w5hq-g745-h8pq (`uuid <14.0.0`, buffer bounds in v3/v5/v6 with `buf`) | moderate | **Ignore** + document |

- **postcss** has two transitive resolutions (`next@16.2.4` pins `8.4.31`; `@tailwindcss/postcss@4.2.3` pulls `^8.5.6`). `overrides.postcss = "8.5.10"` dedupes to the patched version.
- **mdast-util-to-hast** is reached via three independent paths (shiki/rehype-pretty-code, react-markdown, velite/@mdx-js/mdx), all accepting `^13.0.0`. `overrides.mdast-util-to-hast = "^13.2.1"` lifts every resolution to the patched version.
- **uuid** comes only from `resend@6.12.2 → svix@1.90.0 → uuid@^10.0.0`. svix's stated range `^10.0.0` doesn't admit a 14.x override without risking parent CJS imports. Vortex's exposure is theoretical (the `/api/subscribe` endpoint uses Resend's send-email, not svix's webhook-signing path; the vulnerable v3/v5/v6-with-`buf` code isn't called). Documented in `CLAUDE.md` with a removal trigger; CI is gated with `--ignore=GHSA-w5hq-g745-h8pq`.

**ci.yml changes**
- New `Dependency audit` step at the end of the `ci` job: `bun audit --ignore=GHSA-w5hq-g745-h8pq` with no `continue-on-error`.
- New `dependency-review` job (PR-only) using `actions/dependency-review-action@v4.9.0` with `fail-on-severity: high` and `comment-summary-in-pr: on-failure`. Stays `continue-on-error: true` until a baseline of acceptable license/severity findings is established — different gate from `bun audit`.

**Other**
- Added `CLAUDE.md` section "Audit advisories" with one entry per GHSA + removal trigger.
- Added `.claude` to `.gitignore` (matches the sibling Bun + Biome sites' convention; was previously letting harness-generated `.claude/settings.local.json` leak into `biome check` output).

## Verification

```text
$ bun audit --ignore=GHSA-w5hq-g745-h8pq
$ echo $?
0
$ bun pm ls --all | grep -E '^(├── )?(postcss|mdast-util-to-hast)@'
├── mdast-util-to-hast@13.2.1
├── postcss@8.5.10
$ bun run build
✓ Generating static pages (12/12)
```

## Test plan

- [x] CI green (lint, build, typecheck, verify, audit, dependency-review)
- [x] `bun audit` step exits 0 in the green run
- [ ] `dependency-review` job runs (PR-only) and posts no comment (no high-severity findings expected)
- [ ] Browser smoke on Vercel preview: `/blog/<slug>` MDX still renders correctly (Shiki syntax highlighting works), confirming the `mdast-util-to-hast` bump is API-compatible

## Removal triggers (future cleanup)

- Drop `overrides.postcss` after `next` + `@tailwindcss/postcss` ship releases that pull their transitive postcss to ≥ 8.5.10.
- Drop `overrides.mdast-util-to-hast` after parents (most likely shiki) ship releases that pull a patched version directly.
- Drop `--ignore=GHSA-w5hq-g745-h8pq` after svix (or resend) ships a release that bumps uuid to ≥ 14.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)