### PR TITLE
Enable noUncheckedIndexedAccess; guard touch-event index access

### DIFF
--- a/src/components/hero-404/index.tsx
+++ b/src/components/hero-404/index.tsx
@@ -218,8 +218,10 @@ void main() {
         e.preventDefault();
       }
 
-      const touchX = e.touches[0].clientX;
-      const touchY = e.touches[0].clientY;
+      const touch = e.touches[0];
+      if (!touch) return;
+      const touchX = touch.clientX;
+      const touchY = touch.clientY;
 
       const x = (touchX / window.innerWidth) * 2 - 1;
       const y = (touchY / window.innerHeight) * 2 - 1;

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -227,8 +227,10 @@ void main() {
         e.preventDefault();
       }
 
-      const touchX = e.touches[0].clientX;
-      const touchY = e.touches[0].clientY;
+      const touch = e.touches[0];
+      if (!touch) return;
+      const touchX = touch.clientX;
+      const touchY = touch.clientY;
 
       const x = (touchX / window.innerWidth) * 2 - 1;
       const y = (touchY / window.innerHeight) * 2 - 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "bundler",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Turns on TypeScript's `noUncheckedIndexedAccess` in `tsconfig.json`. Under this flag, every array/record index access has type `T | undefined`, surfacing latent unsafe-index bugs across the codebase.

The whole repo turns out to need only **two call-site fixes**, both the same pattern: `e.touches[0]` inside a `touchmove` handler. The browser spec doesn't strictly guarantee `touches` is non-empty during `touchmove` (some implementations fire the event with an empty list at the boundary of a touch ending), so the safest fix is to capture the touch into a local and early-return when it's `undefined`:

```diff
- const touchX = e.touches[0].clientX;
- const touchY = e.touches[0].clientY;
+ const touch = e.touches[0];
+ if (!touch) return;
+ const touchX = touch.clientX;
+ const touchY = touch.clientY;
```

Applied identically in `src/components/hero/index.tsx` and `src/components/hero-404/index.tsx`.

The velite content collection (`#site/content`) was the call surface I expected to be most affected, but the velite-generated types already model collection access safely, so `getAllSlugs` / `getPostBySlug` need no changes.

## Test plan

- [ ] CI green (lint, build, typecheck, verify, audit, dependency-review)
- [ ] Vercel preview: drag the hero on the homepage with a touch device (or DevTools touch emulation) — model still rotates as expected
- [ ] Vercel preview: same on `/404` (the hero-404 variant uses the same touch handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)