### PR TITLE
Enable exactOptionalPropertyTypes; widen optional props that accept undefined

### DIFF
--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -18,7 +18,7 @@ const BASE = process.env.BASE ?? "http://localhost:3000";
 type CheckResult = {
   name: string;
   ok: boolean;
-  msg?: string;
+  msg?: string | undefined;
 };
 
 const results: CheckResult[] = [];

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -6,8 +6,8 @@ export const OG_CONTENT_TYPE = "image/png";
 
 export function renderOgImage(props: {
   title: string;
-  description?: string;
-  eyebrow?: string;
+  description?: string | undefined;
+  eyebrow?: string | undefined;
 }) {
   return new ImageResponse(
     <OgCard
@@ -25,8 +25,8 @@ function OgCard({
   eyebrow
 }: {
   title: string;
-  description?: string;
-  eyebrow?: string;
+  description?: string | undefined;
+  eyebrow?: string | undefined;
 }) {
   return (
     <div

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Turns on TypeScript's `exactOptionalPropertyTypes`, which distinguishes between:

- `prop?: T` — can be omitted entirely (callers must omit, not pass explicit `undefined`)
- `prop?: T | undefined` — optional **and** explicitly accepts `undefined`

Three call sites trip on this, all with the same shape: a value that's genuinely `T | undefined` at the source (frontmatter excerpt, optional check message) being passed into a `prop?: T` slot. The renderer/consumer in each case already handles undefined with a truthiness check, so the natural intent is "optional in either form" — widen the signature to `prop?: T | undefined` rather than reshape the call sites with conditional spreads.

**Type widenings:**

- `scripts/verify.ts` — `CheckResult.msg`: `?: string` → `?: string | undefined`
- `src/lib/og.tsx` — `renderOgImage` params: `description` and `eyebrow` widened on both the public function signature and the internal `OgCard` component

No behavioral change. The OG card still renders the description / eyebrow only when truthy; verify.ts's failure messages still serialize as before. The flag flip is the substantive change; the type tweaks are scaffolding to keep tsc happy.

## Test plan

- [ ] CI green (lint, build, typecheck, verify, audit, dependency-review)
- [ ] Vercel preview: `/blog/<slug>/opengraph-image` renders correctly for posts with and without an excerpt (eyeball both — pick a post with an `excerpt` frontmatter field and one without)
- [ ] `bun run verify` against the preview surfaces failure messages cleanly when intentionally broken (regression check on verify.ts CheckResult plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)